### PR TITLE
switch from `Ember.keys` to `Object.keys`

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -18,7 +18,7 @@ function defaultConfig() {
 }
 
 function bindResponses(request, responseRef){
-  Ember.keys(Responses.STATUS_CODES).forEach((key) => {
+  Object.keys(Responses.STATUS_CODES).forEach((key) => {
     request[key] = (...args) => {
       if (responseRef.response) {
         throw new Error(`[FakeServer] Stubbed Request responded with "${key}" after already responding`);
@@ -28,7 +28,7 @@ function bindResponses(request, responseRef){
       return response;
     };
   });
-  Ember.keys(Responses.RESPONSE_ALIASES).forEach((key) => {
+  Object.keys(Responses.RESPONSE_ALIASES).forEach((key) => {
     let aliases = Responses.RESPONSE_ALIASES[key];
     aliases.forEach((alias) => request[alias] = request[key]);
   });

--- a/tests/unit/stub-request/requests-test.js
+++ b/tests/unit/stub-request/requests-test.js
@@ -16,7 +16,7 @@ module('ember-cli-fake-server:stubRequest responses', {
   }
 });
 
-Ember.keys(STATUS_CODES).forEach((key) => {
+Object.keys(STATUS_CODES).forEach((key) => {
   let code = STATUS_CODES[key];
   const message = `\`request#${key}\` returns status code ${code}`;
 
@@ -41,7 +41,7 @@ Ember.keys(STATUS_CODES).forEach((key) => {
   });
 });
 
-Ember.keys(STATUS_CODES).forEach((key) => {
+Object.keys(STATUS_CODES).forEach((key) => {
   let code = STATUS_CODES[key];
   const message = `returning \`this#${key}\` in request handler returns status code ${code}`;
 


### PR DESCRIPTION
Ember.keys is deprecated http://emberjs.com/deprecations/v1.x/#toc_ember-keys

Tests still pass.
