### PR TITLE
Allow upper case HTTP verbs

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -68,7 +68,7 @@ export function stubRequest(verb, path, callback){
     return returnValue;
   };
 
-  currentServer[verb](path, boundCallback);
+  currentServer[verb.toLowerCase()](path, boundCallback);
 }
 
 let FakeServer = {

--- a/tests/unit/fake-server-test.js
+++ b/tests/unit/fake-server-test.js
@@ -41,6 +41,17 @@ test('stubs ajax calls', (assert) => {
   jQuery.ajax('/blah', {complete:done});
 });
 
+test('stubs ajax calls with upper-case verbs', (assert) => {
+  let done = assert.async();
+  assert.expect(1);
+
+  stubRequest('GET', '/blah', (request) => {
+    assert.ok(true, 'Handled request');
+  });
+
+  jQuery.ajax('/blah', {complete:done});
+});
+
 test('responds to ajax', (assert) => {
   let done = assert.async();
   assert.expect(2);


### PR DESCRIPTION
I prefer writing http verbs in upper case:

``` javascript
stubRequest('GET', 'api/users', function() {
  (...)
});
```

It is both as the the actual http gets sent but also makes it easy to spot the `stubRequests` just by glancing at the file. I hope you share my enthusiasm :)
