### PR TITLE
Add `passthroughRequest`

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -34,6 +34,14 @@ function bindResponses(request, responseRef){
   });
 }
 
+export function passthroughRequest(verb, path) {
+  path = _config.preparePath(path);
+  Ember.assert('[FakeServer] cannot passthrough request if FakeServer is not running',
+               !!currentServer);
+
+  currentServer[verb.toLowerCase()](path, currentServer.passthrough);
+}
+
 export function stubRequest(verb, path, callback){
   path = _config.preparePath(path);
   Ember.assert('[FakeServer] cannot stub request if FakeServer is not running',
@@ -71,7 +79,7 @@ export function stubRequest(verb, path, callback){
   currentServer[verb.toLowerCase()](path, boundCallback);
 }
 
-let FakeServer = {
+const FakeServer = {
   configure: {
     fixtureFactory(fixtureFactory) {
       _config.fixtureFactory = fixtureFactory;
@@ -86,7 +94,7 @@ let FakeServer = {
                  'Ensure you call `FakeServer.stop()` first.',
                  !FakeServer.isRunning());
 
-    currentServer = new Pretender();
+    currentServer = this._currentServer = new Pretender();
     currentServer.prepareBody = JSONUtils.stringifyJSON;
     currentServer.unhandledRequest = Logging.unhandledRequest;
     currentServer.handledRequest = Logging.handledRequest;
@@ -102,7 +110,7 @@ let FakeServer = {
       return;
     }
     currentServer.shutdown();
-    currentServer = null;
+    currentServer = this._currentServer = null;
 
     _config = defaultConfig();
   }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,3 @@
-<h2 id="title">Welcome to Ember.js</h2>
+<h2 id="title">ember-cli-fake-server</h2>
 
 {{outlet}}

--- a/tests/unit/passthrough-request-test.js
+++ b/tests/unit/passthrough-request-test.js
@@ -1,0 +1,45 @@
+/*global QUnit*/
+import FakeServer, { passthroughRequest } from 'ember-cli-fake-server';
+import Pretender from 'pretender';
+import jQuery from 'jquery';
+import Ember from 'ember';
+
+const { module, test } = QUnit;
+
+let passthrough, pretender;
+
+module('ember-cli-fake-server:stubRequest responses', {
+  setup() {
+    FakeServer.start();
+    pretender = FakeServer._currentServer;
+    passthrough = pretender.passthrough;
+  },
+
+  teardown() {
+    if (FakeServer.isRunning()) {
+      FakeServer.stop();
+    }
+  }
+});
+
+test('passthroughRequest paths are passed to Pretender passthrough', (assert) => {
+  let passedPath, passedHandler;
+
+  pretender.get = function(path, handler) {
+    passedPath = path;
+    passedHandler = handler;
+  };
+
+  passthroughRequest('get', '/abc/def');
+
+  assert.equal(passedPath, '/abc/def', 'passes path to pretender');
+  assert.equal(passedHandler, passthrough, 'handler is passthrough handler');
+});
+
+test('calling passthroughRequest when server is not started throws', (assert) => {
+  FakeServer.stop();
+
+  assert.throws(() => {
+    passthroughRequest('get', '/abc/def');
+  }, /cannot passthrough request if FakeServer is not running/);
+});


### PR DESCRIPTION
Adds a named export `passthroughRequest` that can be called with `(verb, path)` and the result will be given to Pretender to passthrough.

fixes #4 
