### PR TITLE
Add parameter to disable handled request logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ The `request` parameter passed to your callback function is the same one (albeit
 
 ember-cli-fake-server is configured to intercept *all* ajax requests after you call `FakeServer.start()`. Any ajax request that was not stubbed before it was made will [throw an error](https://github.com/201-created/ember-cli-fake-server/blob/master/addon/lib/logging.js#L4) explaining the method and path of the unhandled request.
 
+### Request logging
+
+By default ember-cli-fake-server will log all requests that it handles. To enable/disable logging of successfully handled requests, provide an options object to `FakeServer.start()` that defines a `logging` attribute, for example:
+
+```javascript
+FakeServer.start({ logging: false });
+```
+
+Unhandled requests are always logged.
+
 ### Modifying responses
 
 Use `FakeRequest.configure.afterResponse(fn)` to specify an afterResponse

--- a/addon/index.js
+++ b/addon/index.js
@@ -95,16 +95,18 @@ const FakeServer = {
   },
 
 
-  start(LogHandledRequests=true) {
+  start(options = {}) {
     Ember.assert('[FakeServer] Cannot start FakeServer while already started. ' +
                  'Ensure you call `FakeServer.stop()` first.',
                  !FakeServer.isRunning());
+
+    let logging = typeof options.logging === 'undefined' ? true : options.logging;
 
     currentServer = this._currentServer = new Pretender();
     currentServer.prepareBody = JSONUtils.stringifyJSON;
     currentServer.unhandledRequest = Logging.unhandledRequest;
 
-    if (LogHandledRequests) {
+    if (logging) {
         currentServer.handledRequest = Logging.handledRequest;
     }
   },

--- a/addon/index.js
+++ b/addon/index.js
@@ -95,7 +95,7 @@ const FakeServer = {
   },
 
 
-  start() {
+  start(LogHandledRequests=true) {
     Ember.assert('[FakeServer] Cannot start FakeServer while already started. ' +
                  'Ensure you call `FakeServer.stop()` first.',
                  !FakeServer.isRunning());
@@ -103,7 +103,10 @@ const FakeServer = {
     currentServer = this._currentServer = new Pretender();
     currentServer.prepareBody = JSONUtils.stringifyJSON;
     currentServer.unhandledRequest = Logging.unhandledRequest;
-    currentServer.handledRequest = Logging.handledRequest;
+
+    if (LogHandledRequests) {
+        currentServer.handledRequest = Logging.handledRequest;
+    }
   },
 
   isRunning() {


### PR DESCRIPTION
When running test suites with many stubbed AJAX calls, the amount of entries in CI runs pertaining to handled fake-server AJAX requests can be very overwhelming.

This PR just adds a parameter to `FakeServer.start()` that allows disabling of logging handled requests. By default the parameter will be set such that no change to existing behavior will occur unless explicitly changed by the addon user going forward.
