### PR TITLE
Add json parse when the request is 'application/x-www-form-urlencoded'.

### DIFF
--- a/addon/lib/json-utils.js
+++ b/addon/lib/json-utils.js
@@ -7,10 +7,24 @@ export function stringifyJSON(json={}){
 export function jsonFromRequest(request){
   let json = {};
   if (request.requestBody) {
+    // nested try...catch statements to avoid complexity checking the content
+    // type from the headers, as key and value may have multiple formats:
+    // - Key: 'content-type', 'Content-Type'.
+    // - Value: 'application/json', 'application/vnd.api+json'.
     try {
+      // 'Content-Type': 'application/json'
       json = JSON.parse(request.requestBody);
-    } catch(e) {
-      Ember.Logger.warn(`[FakeServer] Failed to parse json from request.requestBody "${request.requestBody}" (error: ${e})`);
+    } catch (e) {
+      try {
+        // 'Content-Type': 'application/x-www-form-urlencoded'
+        json = JSON.parse(
+          '{"'
+          + decodeURIComponent(request.requestBody.replace(/"/g, '\\"').replace(/&/g, '","').replace(/=/g,'":"'))
+          + '"}'
+        );
+      } catch(e) {
+        Ember.Logger.warn(`[FakeServer] Failed to parse json from request.requestBody "${request.requestBody}" (error: ${e})`);
+      }
     }
   }
 

--- a/addon/lib/json-utils.js
+++ b/addon/lib/json-utils.js
@@ -17,11 +17,7 @@ export function jsonFromRequest(request){
     } catch (e) {
       try {
         // 'Content-Type': 'application/x-www-form-urlencoded'
-        json = JSON.parse(
-          '{"'
-          + decodeURIComponent(request.requestBody.replace(/"/g, '\\"').replace(/&/g, '","').replace(/=/g,'":"'))
-          + '"}'
-        );
+        json = JSON.parse('{"' + decodeURIComponent(request.requestBody.replace(/"/g, '\\"').replace(/&/g, '","').replace(/=/g,'":"')) + '"}');
       } catch(e) {
         Ember.Logger.warn(`[FakeServer] Failed to parse json from request.requestBody "${request.requestBody}" (error: ${e})`);
       }

--- a/tests/unit/fake-server-test.js
+++ b/tests/unit/fake-server-test.js
@@ -89,6 +89,52 @@ test('#json reads JSON in request payload', (assert) => {
   });
 });
 
+test('json() function parses x-www-form-urlencoded request payload', (assert) => {
+  let done = assert.async();
+  assert.expect(1);
+
+  const jsonPayload = {
+    foo: 'bar',
+    hello: 'World!',
+  };
+  const urlEncodedPayload = "foo=bar&hello=World!";
+
+  stubRequest('post', '/blah', (request) => {
+    assert.deepEqual(request.json(), jsonPayload, 'POST payload');
+    request.noContent();
+  });
+
+  jQuery.ajax('/blah', {
+    type: 'POST',
+    data: urlEncodedPayload,
+    contentType: 'application/x-www-form-urlencoded',
+    complete: done
+  });
+});
+
+test('json() function parses x-www-form-urlencoded request payload with special characters', (assert) => {
+  let done = assert.async();
+  assert.expect(1);
+
+  const jsonPayload = {
+    foo: 'bar',
+    password: '$€áÉîÖùñÑ',
+  };
+  const urlEncodedPayload = "foo=bar&password=$€áÉîÖùñÑ";
+
+  stubRequest('post', '/blah', (request) => {
+    assert.deepEqual(request.json(), jsonPayload, 'POST payload');
+    request.noContent();
+  });
+
+  jQuery.ajax('/blah', {
+    type: 'POST',
+    data: urlEncodedPayload,
+    contentType: 'application/x-www-form-urlencoded',
+    complete: done
+  });
+});
+
 test('FakeServer.config.afterResponse can modify responses', (assert) => {
   let done = assert.async();
   assert.expect(6);


### PR DESCRIPTION
The current json parse is only valid for requests of type 'application/json', so a valid parse for requests of type 'application/x-www-form-urlencoded' is added.